### PR TITLE
[SMARTI-486] solution to the exception when returning from the payment flow with i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - adding installments functionality to the MLB seller.
 - furyDoc on installments functionality for MLB seller.
 
+## Fixed
+- solution to the exception when returning from the payment flow with installments.
+
 # v2.2.1
 ## Fixed
 - Exception mapping when printing image by bitmap.

--- a/app/src/main/java/com/mercadolibre/android/point_mainapp_demo/app/view/payment/launcher/PaymentFlowInstallmentsActivity.kt
+++ b/app/src/main/java/com/mercadolibre/android/point_mainapp_demo/app/view/payment/launcher/PaymentFlowInstallmentsActivity.kt
@@ -88,13 +88,13 @@ class PaymentFlowInstallmentsActivity : AppCompatActivity() {
             paymentMethod = paymentMethod,
             installments = installment?.toIntOrNull(),
             intentSuccess = paymentFlow.buildCallbackUri(
-                callback = "mercadopago://smart_integrations/payment_result",
+                callback = "mercadopago://launcher_native_app",
                 methodCallback = "success",
                 metadata = hashMapOf("message" to "testSuccess"),
                 appID = "demo.app"
             ),
             intentError = paymentFlow.buildCallbackUri(
-                callback = "mercadopago://smart_integrations/payment_result",
+                callback = "mercadopago://launcher_native_app",
                 methodCallback = "error",
                 metadata = hashMapOf("message" to "testError"),
                 appID = "demo.app"

--- a/app/src/main/java/com/mercadolibre/android/point_mainapp_demo/app/view/payment/launcher/PaymentLauncherActivity.kt
+++ b/app/src/main/java/com/mercadolibre/android/point_mainapp_demo/app/view/payment/launcher/PaymentLauncherActivity.kt
@@ -68,7 +68,7 @@ class PaymentLauncherActivity : AppCompatActivity() {
             sendPaymentActionButton.setOnClickListener {
                 val amount = amountEditText.text?.toString()
                 val description = binding.descriptionEditText.text?.toString()
-                if (lastPaymentMethodSelected == PaymentMethod.CREDIT_CARD.name.lowercase()) {
+                if (lastPaymentMethodSelected == PaymentMethod.CREDIT_CARD.name.lowercase() && !amount.isNullOrEmpty()) {
                     launchActivity(
                         PaymentFlowInstallmentsActivity::class.java,
                         bundleOf(

--- a/app/src/main/res/layout/point_mainapp_demo_app_activity_home.xml
+++ b/app/src/main/res/layout/point_mainapp_demo_app_activity_home.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/primaryLightColor"
-    tools:context=".view.home.HomeActivity">
-
     <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/primaryDarkColor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,14 +35,13 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_actions"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/point_mainapp_demo_app_version"
             tools:listitem="@layout/point_mainapp_demo_app_item_home_action"
             tools:itemCount="5"
             />
 
-
     </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>


### PR DESCRIPTION
…nstallments

# Pull Request

## Ticket
[SMARTI-486](https://mercadolibre.atlassian.net/browse/SMARTI-486)

## Description
<!--Include a list or short summary of the changes that were made. List the dependencies that were required for this change.-->
Se solucionó el error al volver del flujo de pago con cuotas cambiando el deeplink, además se ajusto la validación para mostrar cuotas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

- [x] I added changes made to CHANGELOG.md
- [x] I have validated and corrected code quality comments.
- [x] I selected the correct milestone.
- [x] I selected myself as PR owner.
- [x] Verify that you are merged with the latest in master
- [x] I have validated the pull request name format ([SMARTI-XXXX] Jira ticket title).
- [x] I tested my changes using the DemoApp.

## Screenshots (if applies)
<!-- Control height of your picture with HTML tag -->
<!-- <img height="300" src="<image_url>"> -->
| solution of scroll | solution error field invalid |
|--|--|
| <img height="400" src="https://github.com/mercadolibre/point-mainapp-demo-android/assets/136835377/c609f62a-4fe1-414d-a341-2c2d98e7f529"> | <img height="400" src="https://github.com/mercadolibre/point-mainapp-demo-android/assets/136835377/b76ca0f8-7751-4711-b084-f95577069997"> | 
| solution error go back paymentFlow | solution error field empty |
<img height="400" src="https://github.com/mercadolibre/point-mainapp-demo-android/assets/136835377/a161a111-2883-4921-9e7d-4a523e71054c"> | <img width="300" alt="Captura de pantalla 2023-09-20 a la(s) 12 13 27 p m" src="https://github.com/mercadolibre/point-mainapp-demo-android/assets/136835377/d5663da9-7a24-45e4-a254-33c2311e3260"> |
|--|--|


[SMARTI-486]: https://mercadolibre.atlassian.net/browse/SMARTI-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ